### PR TITLE
statsd client fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ func main() {
 	workload.ReadConfig()
 
 	workload.StartStatsdClient()
-	defer workload.StopStatsdClient()
 
 	admin := api.SyncGatewayClient{}
 	admin.Init(
@@ -126,7 +125,7 @@ func main() {
 
 	workload.ValidateExpvars()
 	writeExpvarsToFile()
-
+	workload.StopStatsdClient()
 }
 
 func createSession(admin *api.SyncGatewayClient, user *workload.User, config workload.Config) {

--- a/workload/workload.go
+++ b/workload/workload.go
@@ -522,7 +522,7 @@ func StartStatsdClient() {
 		defer c.Close()
 
 		ticker := time.NewTicker(1 * time.Second)
-		statsdQuitChannel := make(chan struct{})
+		statsdQuitChannel = make(chan struct{})
 		//Iterate over expvars and write to statsd client
 		go func() {
 			for {


### PR DESCRIPTION
Statsd client now closes after test has completed, statsd client var now uses package context instead of overwriting in local context