### PR TITLE
A candidate fix for the root expvar key/value pairs not being written to statsd

### DIFF
--- a/workload/workload.go
+++ b/workload/workload.go
@@ -531,7 +531,11 @@ func StartStatsdClient() {
 						//log.Printf("Processing glExpvar key: %v, for Type %T", f.Key, f.Value)
 						switch v := f.Value.(type) {
 						case *expvar.Int:
-							c.Gauge(f.Key,v)
+							i, err := strconv.ParseInt(v.String(), 10, 64)
+							log.Printf("Processing root key: %v, vale: %v", f.Key, i)
+							if err == nil {
+								c.Gauge(f.Key,i)
+							}
 						case *expvar.Map:
 							v.Do(func(g expvar.KeyValue) {
 								//log.Printf("Processing expvar.Map key: %v, for Type %T", g.Key, g.Value)

--- a/workload/workload.go
+++ b/workload/workload.go
@@ -528,23 +528,19 @@ func StartStatsdClient() {
 				select {
 				case <-ticker.C:
 					glExpvars.Do(func(f expvar.KeyValue) {
-						//log.Printf("Processing glExpvar key: %v, for Type %T", f.Key, f.Value)
 						switch v := f.Value.(type) {
 						case *expvar.Int:
 							i, err := strconv.ParseInt(v.String(), 10, 64)
-							log.Printf("Processing root key: %v, vale: %v", f.Key, i)
 							if err == nil {
 								c.Gauge(f.Key,i)
 							}
 						case *expvar.Map:
 							v.Do(func(g expvar.KeyValue) {
-								//log.Printf("Processing expvar.Map key: %v, for Type %T", g.Key, g.Value)
 								switch w := g.Value.(type) {
 								case *metrics.HistogramExport:
 									perc := w.Histogram.Percentiles(kStatsPercentiles)
 									for i, p := range perc {
 										compositeKey := f.Key+"."+g.Key+"."+kPercentileNames[i]
-										log.Printf("Processing percentile key: %v, vale: %v", compositeKey, p)
 										c.Gauge(compositeKey, p)
 									}
 								}


### PR DESCRIPTION
Looks like statsd was silently dropping the expvar.Int value types as they a re composite struct that only support a String() method.

Now convert to an int64 type before passing to statsd